### PR TITLE
Small fix in CustomerMessage constructor 

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-ci
+coverage_clover: build/logs/clover.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,4 @@ script:
   - ./vendor/bin/php-cs-fixer fix --dry-run --diff --verbose
 
 after_success:
+  - travis_retry php vendor/bin/coveralls -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/heidelpay/php-customer-messages.svg?style=flat-square)](https://packagist.org/packages/heidelpay/php-customer-messages)
-[![Codacy Badge](https://api.codacy.com/project/badge/grade/7c9b7df7c38841dbb4d485fe83b86eb4)](https://www.codacy.com/app/heidelpay/magento2/dashboard)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/7c9b7df7c38841dbb4d485fe83b86eb4)](https://www.codacy.com/app/heidelpay/php-customer-messages/dashboard)
 
 ![Logo](https://dev.heidelpay.de/devHeidelpay_400_180.jpg)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/heidelpay/php-customer-messages.svg?style=flat-square)](https://packagist.org/packages/heidelpay/php-customer-messages)
+[![Codacy Badge](https://api.codacy.com/project/badge/grade/7c9b7df7c38841dbb4d485fe83b86eb4)](https://www.codacy.com/app/heidelpay/magento2/dashboard)
+
 ![Logo](https://dev.heidelpay.de/devHeidelpay_400_180.jpg)
 
 **heidelpay Customer Messages**

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Heidelpay\\Tests\\CustomerMessages\\": "tests/unit"
+            "Heidelpay\\CustomerMessages\\Tests\\": "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,9 @@
         "php": "^5.6.0|^7.0.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "~5.7",
         "heidelpay/phpdocumentor": "^2.9.1",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "phpunit/phpunit": "~5.7"
+        "satooshi/php-coveralls": "1.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Heidelpay\\CustomerMessages\\Tests\\": "tests/"
+            "Tests\\": "tests/"
         }
     },
     "require": {

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -25,16 +25,16 @@ use Heidelpay\CustomerMessages\Helpers\FileSystem;
 class CustomerMessage
 {
     /** @var FileSystem A helper class for file handling. */
-    private $_filesystem = null;
+    private $filesystem = null;
 
     /** @var string The locale (IETF tag is recommended) to be used by the library. */
-    private $_locale;
+    private $locale;
 
     /** @var string The path of the locale file. */
-    private $_path;
+    private $path;
 
     /** @var array Contains all customer messages. */
-    private $_messages;
+    private $messages;
 
 
     /**
@@ -48,15 +48,15 @@ class CustomerMessage
      */
     public function __construct($locale = 'en_US', $path = null)
     {
-        $this->_locale = $locale;
+        $this->locale = $locale;
 
-        if ( $path ) {
-            $this->_path = $path;
+        if ($path) {
+            $this->path = $path;
         }
 
         // if the locale file does not exist, we better throw an exception
         // instead of just let PHP error_log something.
-        if ( ! file_exists($this->getLocalePath()) ) {
+        if (! file_exists($this->getLocalePath())) {
             throw new MissingLocaleFileException(
                 "Locale file {$this->getLocalePath()} does not exist."
             );
@@ -74,7 +74,7 @@ class CustomerMessage
      */
     public function getLocale()
     {
-        return $this->_locale;
+        return $this->locale;
     }
 
     /**
@@ -94,7 +94,7 @@ class CustomerMessage
      */
     public function getPath()
     {
-        return $this->_path ?: __DIR__ . '/locales';
+        return $this->path ?: __DIR__ . '/locales';
     }
 
     /**
@@ -105,12 +105,12 @@ class CustomerMessage
      */
     public function getMessage($messagecode)
     {
-        if( preg_match('/^\d{3}\.\d{3}\.\d{3}$/', $messagecode) ) {
+        if (preg_match('/^\d{3}\.\d{3}\.\d{3}$/', $messagecode)) {
             $messagecode = 'HPError-' . $messagecode;
         }
 
-        return isset($this->_messages[$messagecode])
-            ? $this->_messages[$messagecode]
+        return isset($this->messages[$messagecode])
+            ? $this->messages[$messagecode]
             : $this->getDefaultMessage($messagecode);
     }
 
@@ -123,8 +123,8 @@ class CustomerMessage
      */
     public function getDefaultMessage($messagecode = '000.000.000')
     {
-        return isset($this->_messages['Default'])
-            ? $this->_messages['Default']
+        return isset($this->messages['Default'])
+            ? $this->messages['Default']
             : "An unspecific error occured. HPErrorcode: {$messagecode}";
     }
 
@@ -136,8 +136,8 @@ class CustomerMessage
     private function setContent()
     {
         // open the fs to retrieve file information.
-        $this->_filesystem = new FileSystem($this->getLocalePath());
-        $this->_messages = $this->_filesystem->getCsvContent();
+        $this->filesystem = new FileSystem($this->getLocalePath());
+        $this->messages = $this->filesystem->getCsvContent();
     }
 
 }

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -21,7 +21,6 @@ use Heidelpay\CustomerMessages\Helpers\FileSystem;
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
 class CustomerMessage
 {
     /** @var FileSystem A helper class for file handling. */
@@ -56,7 +55,7 @@ class CustomerMessage
 
         // if the locale file does not exist, we better throw an exception
         // instead of just let PHP error_log something.
-        if (! file_exists($this->getLocalePath())) {
+        if (!file_exists($this->getLocalePath())) {
             throw new MissingLocaleFileException(
                 "Locale file {$this->getLocalePath()} does not exist."
             );

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -13,7 +13,7 @@ use Heidelpay\CustomerMessages\Helpers\FileSystem;
  * The path is important when own implementations have to be used.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
  *
  * @link https://dev.heidelpay.de/php-customer-messages
  *
@@ -26,16 +26,16 @@ use Heidelpay\CustomerMessages\Helpers\FileSystem;
 class CustomerMessage
 {
     /** @var FileSystem A helper class for file handling. */
-    private $filesystem = null;
+    private $_filesystem = null;
 
     /** @var string The locale (IETF tag is recommended) to be used by the library. */
-    private $locale;
+    private $_locale;
 
     /** @var string The path of the locale file. */
-    private $path;
+    private $_path;
 
     /** @var array Contains all customer messages. */
-    private $messages;
+    private $_messages;
 
     /**
      * The CustomerMessage constructor, which accepts the locale and
@@ -43,13 +43,13 @@ class CustomerMessage
      * path - so that own locale files can be used.
      *
      * @param string $locale (optional) The locale for the language to be used.
-     * @param string $path (optional)
+     * @param string $path   (optional)
      *
      * @throws MissingLocaleFileException
      */
     public function __construct($locale = 'en_US', $path = null)
     {
-        $this->locale = $locale;
+        $this->_locale = $locale;
 
         if ($path !== null && is_string($path)) {
             $this->path = $path;
@@ -57,7 +57,7 @@ class CustomerMessage
 
         // if the locale file does not exist, we better throw an exception
         // instead of just let PHP error_log something.
-        if (!file_exists($this->getLocalePath())) {
+        if (! file_exists($this->getLocalePath())) {
             throw new MissingLocaleFileException(
                 "Locale file {$this->getLocalePath()} does not exist."
             );
@@ -75,7 +75,7 @@ class CustomerMessage
      */
     public function getLocale()
     {
-        return $this->locale;
+        return $this->_locale;
     }
 
     /**
@@ -95,7 +95,7 @@ class CustomerMessage
      */
     public function getPath()
     {
-        return $this->path ?: __DIR__ . '/locales';
+        return $this->_path ?: __DIR__ . '/locales';
     }
 
     /**
@@ -111,8 +111,8 @@ class CustomerMessage
             $messagecode = 'HPError-' . $messagecode;
         }
 
-        return isset($this->messages[$messagecode])
-            ? $this->messages[$messagecode]
+        return isset($this->_messages[$messagecode])
+            ? $this->_messages[$messagecode]
             : $this->getDefaultMessage($messagecode);
     }
 
@@ -126,8 +126,8 @@ class CustomerMessage
      */
     public function getDefaultMessage($messagecode = '000.000.000')
     {
-        return isset($this->messages['Default'])
-            ? $this->messages['Default']
+        return isset($this->_messages['Default'])
+            ? $this->_messages['Default']
             : "An unspecific error occured. HPErrorcode: {$messagecode}";
     }
 
@@ -139,7 +139,7 @@ class CustomerMessage
     private function setContent()
     {
         // open the fs to retrieve file information.
-        $this->filesystem = new FileSystem($this->getLocalePath());
-        $this->messages = $this->filesystem->getCsvContent();
+        $this->_filesystem = new FileSystem($this->getLocalePath());
+        $this->_messages = $this->_filesystem->getCsvContent();
     }
 }

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -13,8 +13,10 @@ use Heidelpay\CustomerMessages\Helpers\FileSystem;
  * The path is important when own implementations have to be used.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
- * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved
+ *
  * @link https://dev.heidelpay.de/php-customer-messages
+ *
  * @author Stephano Vogel
  *
  * @package heidelpay
@@ -35,14 +37,14 @@ class CustomerMessage
     /** @var array Contains all customer messages. */
     private $messages;
 
-
     /**
      * The CustomerMessage constructor, which accepts the locale and
      * an optional different path that may not be the library's
      * path - so that own locale files can be used.
      *
      * @param string $locale (optional) The locale for the language to be used.
-     * @param string $path (optional)
+     * @param string $path   (optional)
+     *
      * @throws MissingLocaleFileException
      */
     public function __construct($locale = 'en_US', $path = null)
@@ -100,6 +102,7 @@ class CustomerMessage
      * Returns a message for the given message code.
      *
      * @param string $messagecode The heidelpay message code
+     *
      * @return string The customer message that will be displayed
      */
     public function getMessage($messagecode)
@@ -118,6 +121,7 @@ class CustomerMessage
      * is not specified in the locale file.
      *
      * @param string $messagecode The message code that will be displayed if no default is set.
+     *
      * @return string The customer message that will be displayed if the error code is not defined.
      */
     public function getDefaultMessage($messagecode = '000.000.000')
@@ -138,5 +142,4 @@ class CustomerMessage
         $this->filesystem = new FileSystem($this->getLocalePath());
         $this->messages = $this->filesystem->getCsvContent();
     }
-
 }

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -1,4 +1,10 @@
 <?php
+
+namespace Heidelpay\CustomerMessages;
+
+use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
+use Heidelpay\CustomerMessages\Helpers\FileSystem;
+
 /**
  * This class provides a user-friendly printing of heidelpay error-codes.
  *
@@ -15,11 +21,6 @@
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
-namespace Heidelpay\CustomerMessages;
-
-use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
-use Heidelpay\CustomerMessages\Helpers\FileSystem;
 
 class CustomerMessage
 {
@@ -89,7 +90,7 @@ class CustomerMessage
     /**
      * Returns the path for the locale file.
      *
-     * @return string  Path of the locale file
+     * @return string Path of the locale file
      */
     public function getPath()
     {

--- a/lib/CustomerMessage.php
+++ b/lib/CustomerMessage.php
@@ -43,7 +43,7 @@ class CustomerMessage
      * path - so that own locale files can be used.
      *
      * @param string $locale (optional) The locale for the language to be used.
-     * @param string $path   (optional)
+     * @param string $path (optional)
      *
      * @throws MissingLocaleFileException
      */
@@ -51,7 +51,7 @@ class CustomerMessage
     {
         $this->locale = $locale;
 
-        if ($path) {
+        if ($path !== null && is_string($path)) {
             $this->path = $path;
         }
 

--- a/lib/Exceptions/MissingLocaleFileException.php
+++ b/lib/Exceptions/MissingLocaleFileException.php
@@ -1,4 +1,9 @@
 <?php
+
+namespace Heidelpay\CustomerMessages\Exceptions;
+
+use Exception;
+
 /**
  * This class is used for indicating a missing locale file for the library usage.
  *
@@ -11,10 +16,6 @@
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
-namespace Heidelpay\CustomerMessages\Exceptions;
-
-use Exception;
 
 class MissingLocaleFileException extends Exception
 {

--- a/lib/Exceptions/MissingLocaleFileException.php
+++ b/lib/Exceptions/MissingLocaleFileException.php
@@ -16,7 +16,6 @@ use Exception;
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
 class MissingLocaleFileException extends Exception
 {
 }

--- a/lib/Exceptions/MissingLocaleFileException.php
+++ b/lib/Exceptions/MissingLocaleFileException.php
@@ -9,7 +9,9 @@ use Exception;
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
  * @link https://dev.heidelpay.de/php-customer-messages
+ *
  * @author Stephano Vogel
  *
  * @package heidelpay

--- a/lib/Helpers/FileSystem.php
+++ b/lib/Helpers/FileSystem.php
@@ -17,9 +17,7 @@ namespace Heidelpay\CustomerMessages\Helpers;
 
 class FileSystem
 {
-    /*
-     * @var resource $_handle
-     */
+    /** @var resource The file handler for the locale file */
     private $_handle;
 
     /**

--- a/lib/Helpers/FileSystem.php
+++ b/lib/Helpers/FileSystem.php
@@ -18,7 +18,7 @@ namespace Heidelpay\CustomerMessages\Helpers;
 class FileSystem
 {
     /** @var resource The file handler for the locale file */
-    private $_handle;
+    private $handle;
 
     /**
      * The FileSystem constructor that creates the file handler.
@@ -28,7 +28,7 @@ class FileSystem
     public function __construct($path)
     {
         // we just want to read files, so mode 'r' will be fine at all.
-        $this->_handle = fopen($path, 'r');
+        $this->handle = fopen($path, 'r');
     }
 
     /**
@@ -38,7 +38,7 @@ class FileSystem
     {
         // no matter what, we want to close the handle as
         // soon as this instance is not needed anymore.
-        fclose($this->_handle);
+        fclose($this->handle);
     }
 
     /**
@@ -53,16 +53,15 @@ class FileSystem
 
         // instead of returning an array for each element, we create
         // an array with the error-code as key and the message as value.
-        while ( $content = fgetcsv($this->_handle) ) {
-
+        while ($content = fgetcsv($this->handle)) {
             // 0 = HPError-Code, 1 = Message
-            if ( isset($content[0]) && isset($content[1]) ) {
+            if (isset($content[0]) && isset($content[1])) {
                 $ret[$content[0]] = $content[1];
             }
         }
 
         // reset the file pointer, if we want to read the file again.
-        rewind($this->_handle);
+        rewind($this->handle);
 
         // return the array.
         return $ret;

--- a/lib/Helpers/FileSystem.php
+++ b/lib/Helpers/FileSystem.php
@@ -7,14 +7,15 @@ namespace Heidelpay\CustomerMessages\Helpers;
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
  * @link https://dev.heidelpay.de/php-customer-messages
+ *
  * @author Stephano Vogel
  *
  * @package heidelpay
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
 class FileSystem
 {
     /** @var resource The file handler for the locale file */

--- a/lib/Helpers/FileSystem.php
+++ b/lib/Helpers/FileSystem.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Heidelpay\CustomerMessages\Helpers;
+
 /**
  * This class provides the functionality for reading the locale files.
  *
@@ -11,8 +14,6 @@
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
-namespace Heidelpay\CustomerMessages\Helpers;
 
 class FileSystem
 {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,17 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/3.7/phpunit.xsd"
-        bootstrap="vendor/autoload.php"
-        colors="true"
- >
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+         bootstrap="tests/bootstrap.php"
+>
     <testsuites>
-        <testsuite name="customerMessages">
+        <testsuite name="heidelpay customerMessages Testsuite">
             <directory>./tests/unit/</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="heidelpay customerMessages Testsuite">

--- a/tests/unit/customerMessagesTest.php
+++ b/tests/unit/customerMessagesTest.php
@@ -2,23 +2,24 @@
 
 namespace Tests\Unit;
 
+use Heidelpay\CustomerMessages\CustomerMessage;
+use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
+use PHPUnit\Framework\TestCase;
+
 /**
  * This class provides unit tests for the CustomerMessage implementation.
  *
  * @license Use of this software requires acceptance of the License Agreement. See LICENSE file.
  * @copyright Copyright © 2016-present Heidelberger Payment GmbH. All rights reserved.
+ *
  * @link https://dev.heidelpay.de/php-customer-messages
+ *
  * @author Stephano Vogel
  *
  * @package heidelpay
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
-
-use Heidelpay\CustomerMessages\CustomerMessage;
-use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
-use PHPUnit\Framework\TestCase;
-
 class CustomerMessagesTest extends TestCase
 {
     /**
@@ -125,5 +126,4 @@ class CustomerMessagesTest extends TestCase
         $message = new CustomerMessage('ab_CD');
         echo $message->getMessage('HPError-100.100.101');
     }
-
 }

--- a/tests/unit/customerMessagesTest.php
+++ b/tests/unit/customerMessagesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Heidelpay\CustomerMessages\Tests\Unit;
+namespace Tests\Unit;
 
 /**
  * This class provides unit tests for the CustomerMessage implementation.

--- a/tests/unit/customerMessagesTest.php
+++ b/tests/unit/customerMessagesTest.php
@@ -106,7 +106,7 @@ class CustomerMessagesTest extends TestCase {
         // we expect the default message, because error 987.654.321 might not exist
         // in the default locale file en_US.csv.
         $this->assertEquals(
-            'Es ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns f&uumlr weitere Informationen.',
+            'Es ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns f&uuml;r weitere Informationen.',
             $message->getMessage('987.654.321')
         );
     }

--- a/tests/unit/customerMessagesTest.php
+++ b/tests/unit/customerMessagesTest.php
@@ -1,10 +1,6 @@
 <?php
 
-namespace Heidelpay\Tests\CustomerMessages;
-
-use Heidelpay\CustomerMessages\CustomerMessage;
-use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
-use PHPUnit\Framework\TestCase;
+namespace Heidelpay\CustomerMessages\Tests\Unit;
 
 /**
  * This class provides unit tests for the CustomerMessage implementation.
@@ -18,6 +14,10 @@ use PHPUnit\Framework\TestCase;
  * @subpackage php-customer-messages
  * @category php-customer-messages
  */
+
+use Heidelpay\CustomerMessages\CustomerMessage;
+use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
+use PHPUnit\Framework\TestCase;
 
 class CustomerMessagesTest extends TestCase
 {
@@ -121,7 +121,9 @@ class CustomerMessagesTest extends TestCase
     public function throwMissingLocaleFileException()
     {
         $this->expectException(MissingLocaleFileException::class);
+
         $message = new CustomerMessage('ab_CD');
+        echo $message->getMessage('HPError-100.100.101');
     }
 
 }

--- a/tests/unit/customerMessagesTest.php
+++ b/tests/unit/customerMessagesTest.php
@@ -1,4 +1,11 @@
 <?php
+
+namespace Heidelpay\Tests\CustomerMessages;
+
+use Heidelpay\CustomerMessages\CustomerMessage;
+use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
+use PHPUnit\Framework\TestCase;
+
 /**
  * This class provides unit tests for the CustomerMessage implementation.
  *
@@ -12,14 +19,8 @@
  * @category php-customer-messages
  */
 
-namespace Heidelpay\Tests\CustomerMessages;
-
-use Heidelpay\CustomerMessages\CustomerMessage;
-use Heidelpay\CustomerMessages\Exceptions\MissingLocaleFileException;
-use PHPUnit\Framework\TestCase;
-
-class CustomerMessagesTest extends TestCase {
-
+class CustomerMessagesTest extends TestCase
+{
     /**
      * Unit test for the correct locale after object initialization.
      *


### PR DESCRIPTION
This fix ensures that the path has to be a string and cannot be null.